### PR TITLE
Replace dev version details with getFullPrettyVersion()

### DIFF
--- a/Plugin.php
+++ b/Plugin.php
@@ -59,10 +59,10 @@ class Plugin implements PluginInterface, EventSubscriberInterface {
     // $lock = $this->composer->getLocker()->getLockData();
     // $content_hash = $lock['content-hash'];
 
-    $package_names = [];
     foreach ($packages as $package) {
       $pretty_version = $package->getFullPrettyVersion(FALSE);
-      // BC use : instead of space.
+      // For backwards compatibility use ':' instead of space to separate
+      // friendly name from revision hash.
       $output_version = str_replace(' ', ':', $pretty_version);
       $package_versions[$package->getName()] = $output_version;
     }

--- a/Plugin.php
+++ b/Plugin.php
@@ -61,24 +61,9 @@ class Plugin implements PluginInterface, EventSubscriberInterface {
 
     $package_names = [];
     foreach ($packages as $package) {
-      $pretty_version = $package->getPrettyVersion();
-      $output_version = $pretty_version;
-
-      // If the package is using a dev version, append the git commit SHA so
-      // that we can see changes to the actual version used.
-      // (No idea why it's sometimes a dev- prefix and sometimes a -dev suffix,
-      // but check for both.)
-      if (substr($pretty_version, 0, 4) == 'dev-' || substr($pretty_version, -4) == '-dev') {
-        $reference = $package->getSourceReference();
-
-        // Fall back to the dist reference if the source reference is empty.
-        if (empty($reference)) {
-          $reference = $package->getDistReference();
-        }
-
-        $output_version .= ':' . $reference;
-      }
-
+      $pretty_version = $package->getFullPrettyVersion(FALSE);
+      // BC use : instead of space.
+      $output_version = str_replace(' ', ':', $pretty_version);
       $package_versions[$package->getName()] = $output_version;
     }
 


### PR DESCRIPTION
Regarding the follow-up from #7 , this works well and simplifies the code for composer 1 and 2

This allowed it to work but the dev-master version looks like this now, so might need a bit more work:

```
-    ubccs/recipes: 'dev-master:882b05c4a9823b5d6915a8f4708ed60a6dbcfb47'
+    ubccs/recipes: '9999999-dev:2bcb71621c58464d913c0142ed625439a1a4128e'
```
