### PR TITLE
Update symfony/yaml dependency to support v5 and v6

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
     ],
     "require": {
         "composer-plugin-api": "^1.0 || ^2.0",
-        "symfony/yaml": "^3.4 || ^4.2"
+        "symfony/yaml": "^3.4 || ^4.2 || ^5.4 || ^6.1"
     },
     "require-dev": {
         "composer/composer": "^1.0 || ^2.0",


### PR DESCRIPTION
I would like to use this project on a Laravel 9 site.

Laravel 9 depends on symphony/yaml 5.x or 6.x. So I've just added those to the version constraints. 

I've tested on PHP 8.1 and it's working fine!