### PR TITLE
Exclude package aliases when generating output

### DIFF
--- a/Plugin.php
+++ b/Plugin.php
@@ -6,6 +6,7 @@ use Composer\Composer;
 use Composer\EventDispatcher\EventSubscriberInterface;
 use Composer\Installer\PackageEvents;
 use Composer\IO\IOInterface;
+use Composer\Package\AliasPackage;
 use Composer\Plugin\PluginInterface;
 use Composer\Script\ScriptEvents;
 use Composer\EventDispatcher\Event as BaseEvent;
@@ -52,7 +53,12 @@ class Plugin implements PluginInterface, EventSubscriberInterface {
   public function updateManifest(BaseEvent $event) {
     $repositoryManager = $this->composer->getRepositoryManager();
     $localRepository = $repositoryManager->getLocalRepository();
-    $packages = $localRepository->getPackages();
+    $packages = array_filter($localRepository->getPackages(), function ($package) {
+      // Only include real packages, not their aliases. This prevents
+      // inconsistent $packages order from causing variability in the
+      // manifest output.
+      return !($package instanceof AliasPackage);
+    });
 
     // TODO: do we want to include the lock hash? Not sure it's useful, and it's
     // a PITA in merge conflicts.


### PR DESCRIPTION
For a package with version aliases, the order of `$packages` seems to be inconsistent between install/require/update operations, which can cause a package in the manifest to switch back and forth between these versions.

My proposal is to filter out any package alias entries. Is there any reason we would need to know about them?

## Example

Fresh project:
```shell
$ composer require --dev joachim-n/composer-manifest
$ composer require --dev grasmash/drupal-security-warning:1.x-dev
```

`composer-manifest.yaml` contains:
```yaml
packages:
    grasmash/drupal-security-warning: '1.x-dev:848fd28335c984ca1ceb9454f7d636465db5c5f8'
    joachim-n/composer-manifest: 1.1.5
    symfony/polyfill-ctype: v1.27.0
    symfony/yaml: v6.2.7
```

But after:
```shell
$ composer update -w
```

Even if no packages were updated, `composer-manifest.yaml` now contains (first package version is different):
```yaml
packages:
    grasmash/drupal-security-warning: 'dev-master:848fd28335c984ca1ceb9454f7d636465db5c5f8'
    joachim-n/composer-manifest: 1.1.5
    symfony/polyfill-ctype: v1.27.0
    symfony/yaml: v6.2.7
```

Then, with:
```shell
$ rm -rf vendor
$ composer install
```

We're back to:
```yaml
packages:
    grasmash/drupal-security-warning: '1.x-dev:848fd28335c984ca1ceb9454f7d636465db5c5f8'
    joachim-n/composer-manifest: 1.1.5
    symfony/polyfill-ctype: v1.27.0
    symfony/yaml: v6.2.7
```

After this PR, version should be `dev-master` in all cases.