### PR TITLE
Add tweaks for Renovate integration

### DIFF
--- a/Plugin.php
+++ b/Plugin.php
@@ -17,11 +17,6 @@ use Symfony\Component\Yaml\Yaml;
 class Plugin implements PluginInterface, EventSubscriberInterface {
 
   /**
-   * @var \Composer\Composer $composer
-   */
-  protected $composer;
-
-  /**
    * @param \Composer\Composer $composer
    * @param \Composer\IO\IOInterface $io
    */
@@ -29,8 +24,6 @@ class Plugin implements PluginInterface, EventSubscriberInterface {
     // Development: this makes symfony var-dumper work.
     // See https://github.com/composer/composer/issues/7911
     // include './vendor/symfony/var-dumper/Resources/functions/dump.php';
-
-    $this->composer = $composer;
   }
 
   /**
@@ -49,9 +42,10 @@ class Plugin implements PluginInterface, EventSubscriberInterface {
    *
    * @param \Composer\EventDispatcher\Event $event
    */
-  public function updateManifest(BaseEvent $event) {
-    $repositoryManager = $this->composer->getRepositoryManager();
+  public static function updateManifest(BaseEvent $event) {
+    $repositoryManager = $event->getComposer()->getRepositoryManager();
     $localRepository = $repositoryManager->getLocalRepository();
+    $localRepository->reload();
     $packages = $localRepository->getPackages();
 
     // TODO: do we want to include the lock hash? Not sure it's useful, and it's
@@ -80,6 +74,7 @@ class Plugin implements PluginInterface, EventSubscriberInterface {
 
     $yaml = Yaml::dump($yaml_data);
     file_put_contents('composer-manifest.yaml', $yaml);
+    $event->getIO()->write('<info>Composer manifest updated!</info>');
   }
 
   /**

--- a/README.md
+++ b/README.md
@@ -25,7 +25,46 @@ composer-manifest.yaml file in your project root. You should commit this to
 version control at the same time as you commit changes to composer.json and
 composer.lock to keep a history of changes.
 
-### Integrations
+## Integrations
 
-With [Renovate](https://github.com/renovatebot/renovate), use the fileFilters
-config option to ensure the manifest file is committed by the renovate bot.
+### Renovate
+
+With [Renovate](https://github.com/renovatebot/renovate), use the post upgrade
+tasks in the project-specific configuration to ensure that the manifest file is
+committed by the renovate bot. Note that the composer script command must be
+added to the allowed post upgrade commands in the global configuration.
+
+#### Project-specific configuration
+
+Add the following post upgrade tasks to the `renovate.json` file. See 
+[Configuration Options: postUpgradeTasks](https://docs.renovatebot.com/configuration-options/#postupgradetasks) for reference.
+
+```json
+{
+  "postUpgradeTasks": {
+    "commands": ["composer update-manifest"],
+    "fileFilters": ["composer-manifest.yaml"],
+    "executionMode": "branch"
+  }
+}
+```
+
+Add the following script to the `composer.json` file. This way no extra
+resources are used for other event listeners.
+
+```json
+{
+  "scripts": {
+    "update-manifest": "ComposerManifest\\Plugin::updateManifest"
+  }
+}
+```
+#### Global configuration
+
+See [Self-Hosted configuration options: allowedPostUpgradeCommands](https://docs.renovatebot.com/self-hosted-configuration/#allowedpostupgradecommands) for reference.
+
+```json
+{
+  allowedPostUpgradeCommands: ['^composer update-manifest$']
+}
+```


### PR DESCRIPTION
This pull request introduces tweaks to make Composer Manifest integrate better with Renovate. Specifically, we faced the issue that the manifest file should be committed with the merge requests automatically generated by the Renovate bot. The changes include:

- Make composer manifest update callable from a script.
- Call a reload to retrieve the latest repository information.
- Provide a more specific description of the Renovate integration in the readme.
- Add I/O confirmation message.